### PR TITLE
Remove duplicate producer ping check

### DIFF
--- a/main.go
+++ b/main.go
@@ -56,9 +56,6 @@ func main() {
 		log.Fatal(err)
 	}
 	defer producer.Close()
-	if err := producer.Ping(ctx); err != nil {
-		log.Fatal(err)
-	}
 	log.Info("Connected to broker")
 
 	// Read the template file for the JSON structure


### PR DESCRIPTION
- remove redundant `producer.Ping` call and log broker connection once
